### PR TITLE
Fix: Supply complete character object to generate-story-chapters

### DIFF
--- a/src/hooks/useStories.ts
+++ b/src/hooks/useStories.ts
@@ -110,7 +110,7 @@ export const useStories = () => {
         // 1) Buscar URL da imagem de referência
         const { data: charData, error: charError } = await supabase
           .from('characters')
-          .select('image_url')
+          .select('nome, idade, sexo, corPele, corCabelo, corOlhos')
           .eq('id', characterId)
           .single();
         if (charError || !charData) {
@@ -127,7 +127,7 @@ export const useStories = () => {
               apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
               Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`
             },
-            body: JSON.stringify({ storyTitle, characterId, characterImageUrl: charData.image_url })
+            body: JSON.stringify({ storyTitle, characterId, character: charData })
           }
         );
         if (!res.ok) {


### PR DESCRIPTION
The generate-story-chapters edge function was failing due to a missing 'character' object in the payload. The client was incorrectly sending 'characterImageUrl' instead.

This commit updates the `useStories` hook to:
1. Fetch the full character details (name, age, gender, appearance) from the 'characters' table.
2. Send these details as a 'character' object in the payload to the 'generate-story-chapters' function.
3. Remove 'characterImageUrl' from the payload, as this is handled internally by the edge function.

This ensures the edge function receives all required parameters, resolving the error.